### PR TITLE
simple patch - AssemblyManager.cs

### DIFF
--- a/Source/ExcelDna.Loader/AssemblyManager.cs
+++ b/Source/ExcelDna.Loader/AssemblyManager.cs
@@ -106,7 +106,8 @@ namespace ExcelDna.Loader
 			{
 				loadedAssembly = Assembly.Load(assemblyBytes);
                 Logger.Initialization.Info("Assembly Loaded from bytes. FullName: {0}", loadedAssembly.FullName);
-				loadedAssemblies.Add(name, loadedAssembly);
+				if(!loadedAssemblies.ContainsKey(name))
+				  loadedAssemblies.Add(name, loadedAssembly);
 				return loadedAssembly;
 			}
 			catch (Exception e)


### PR DESCRIPTION
before adding assembly to dictionary of already loaded assemblies, check that it hasn't been loaded since first check was made to see if it had been loaded